### PR TITLE
Make script/bootstrap more portable

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # Usage: script/bootstrap
 # Sets up required modules for development.
 

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -13,5 +13,5 @@ VERSION="$1"
 sed -i "" "s/tailor-[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/tailor-${VERSION}/g" Dockerfile
 
 # Remove old version of Tailor, download and extract new version
-[ -e tailor-*.tar ] && rm tailor-*.tar
+rm -f tailor-*.tar
 curl -#fLO https://github.com/sleekbyte/tailor/releases/download/v"${VERSION}"/tailor-"${VERSION}".tar

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -10,7 +10,8 @@ set -euo pipefail
 VERSION="$1"
 
 # Update Tailor version in Dockerfile
-sed -i "" "s/tailor-[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/tailor-${VERSION}/g" Dockerfile
+sed "s/tailor-[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/tailor-${VERSION}/g" Dockerfile > Dockerfile.new
+mv Dockerfile.new Dockerfile
 
 # Remove old version of Tailor, download and extract new version
 rm -f tailor-*.tar


### PR DESCRIPTION
There were a couple things in `script/bootstrap` that could fail to work on some OSes. There's a few changes here that should help make the script more portable.