### PR TITLE
Upgrade to Tailor 0.10.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,11 @@ MAINTAINER Sleekbyte
 RUN useradd -u 9000 -r -s /bin/false app
 
 WORKDIR /code
-ADD tailor-0.9.0.tar /usr/src/app
+ADD tailor-0.10.0.tar /usr/src/app
 
 USER app
 VOLUME /code
 
 ENV JAVA_OPTS="-XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=30"
 
-CMD ["/usr/src/app/tailor-0.9.0/bin/tailor", "--format", "cc"]
+CMD ["/usr/src/app/tailor-0.10.0/bin/tailor", "--format", "cc", "--purge", "20"]

--- a/engine.json
+++ b/engine.json
@@ -6,6 +6,6 @@
         "email": "team@sleekbyte.com"
     },
     "languages" : ["Swift"],
-    "version": "0.9.0",
+    "version": "0.10.0",
     "spec_version": "0.2.0"
 }


### PR DESCRIPTION
And use the `--purge` option to prevent memory exhaustion in containers.